### PR TITLE
Update filters.py

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -49,6 +49,7 @@ def not_snps(ds):
         vectorize=True,
         dask="parallelized",
         output_dtypes=[bool],
+        dask_gufunc_kwargs={"allow_rechunk": True},
     )
 
 


### PR DESCRIPTION
A ValueError is raised if `dask=parallelized` and the `allow_rechunk` argument isn't passed to the xarray function at https://github.com/benjeffery/tsinfer-snakemake/blob/5a968cc250b8299271f06e46b9e091895d64d828/filters.py#L45