### PR TITLE
Distribute bio2zarr

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -56,31 +56,78 @@ rule all:
         ),
 
 
-rule bio2zarr_explode:
+checkpoint bio2zarr_dexplode_init:
     input:
         vcf=lambda wildcards: config["vcf"].format(chrom=wildcards.chrom_num),
         tbi=lambda wildcards: config["vcf"].format(chrom=wildcards.chrom_num) + ".tbi",
     output:
-        directory(data_dir / "exploded_vcfs" / "chr{chrom_num}"),
-    threads: config["max_threads"]
+        data_dir / "exploded_vcfs" / "chr{chrom_num}" / "num_partitions",
+    threads: 1
     resources:
-        mem_mb=config["max_mem"],
-        time_min=config["max_time"],
-        runtime=config["max_time"],
+        mem_mb=16_000,
+        time_min=4 * 60,
+        runtime=4 * 60,
     run:
-        from bio2zarr import vcf
+        import json
 
-        vcf.explode(
-            output[0],
-            [input.vcf],
-            worker_processes=threads,
-            column_chunk_size=config["bio2zarr"]["column_chunk_size"],
+        shell(
+            f"python -m bio2zarr vcf2zarr dexplode-init --force --num-partitions {config['bio2zarr']['num_partitions']} {input.vcf} {Path(output[0]).parent}"
+        )
+        # Write num partitions to a file that doesn't get deleted
+        with open(Path(output[0]).parent / "wip" / "metadata.json", "r") as f:
+            metadata = json.load(f)
+            num_partitions = len(metadata["partitions"])
+        with open(output[0], "w") as f:
+            f.write(str(num_partitions))
+
+
+rule bio2zarr_dexplode_partition:
+    input:
+        data_dir / "exploded_vcfs" / "chr{chrom_num}" / "num_partitions",
+    output:
+        data_dir / "exploded_vcfs" / "chr{chrom_num}" / ".done_{partition}",
+    threads: 1
+    resources:
+        mem_mb=16_000,
+        time_min=4 * 60,
+        runtime=4 * 60,
+    run:
+        shell(
+            f"python -m bio2zarr vcf2zarr dexplode-partition {Path(input[0]).parent} {wildcards.partition} && touch {output[0]}"
+        )
+
+
+def dexplode_partitions(wildcards):
+    checkpoint_output = checkpoints.bio2zarr_dexplode_init.get(
+        chrom_num=wildcards.chrom_num
+    )
+    with open(checkpoint_output.output[0], "r") as f:
+        num_partitions = int(f.read())
+    return [
+        data_dir / "exploded_vcfs" / f"chr{wildcards.chrom_num}" / f".done_{p}"
+        for p in range(num_partitions)
+    ]
+
+
+rule bio2zarr_dexplode_finalise:
+    input:
+        dexplode_partitions,
+    output:
+        data_dir / "exploded_vcfs" / "chr{chrom_num}" / ".done",
+    threads: 1
+    resources:
+        mem_mb=16_000,
+        time_min=4 * 60,
+        runtime=4 * 60,
+    run:
+        shell(
+            f"python -m bio2zarr vcf2zarr dexplode-finalise {Path(output[0]).parent} && touch {output[0]}"
         )
 
 
 rule bio2zarr_mkschema:
     input:
-        data_dir / "exploded_vcfs" / "chr{chrom_num}",
+        data_dir / "exploded_vcfs" / "chr{chrom_num}" / ".done",
     output:
         data_dir / "zarr_vcfs_schema" / "chr{chrom_num}" / "schema.json",
     threads: 1
@@ -89,46 +136,91 @@ rule bio2zarr_mkschema:
         time_min=4 * 60,
         runtime=4 * 60,
     run:
-        from bio2zarr import vcf
-
         Path(output[0]).parent.mkdir(parents=True, exist_ok=True)
-        with open(output[0], "w") as out:
-            vcf.mkschema(
-                input[0],
-                out,
-            )
+        shell(
+            f"python -m bio2zarr vcf2zarr mkschema {Path(input[0]).parent} > {output[0]}"
+        )
 
 
-rule bio2zarr_encode:
+checkpoint bio2zarr_dencode_init:
     input:
-        data_dir / "exploded_vcfs" / "chr{chrom_num}",
+        data_dir / "exploded_vcfs" / "chr{chrom_num}" / ".done",
         data_dir / "zarr_vcfs_schema" / "chr{chrom_num}" / "schema.json",
     output:
-        data_dir / "zarr_vcfs" / "chr{chrom_num}" / "data.zarr" / ".vcf_done",
-    threads: config["max_threads"]
+        data_dir / "zarr_vcfs" / "chr{chrom_num}" / "data.zarr" / "num_partitions",
+    threads: 1
     resources:
-        mem_mb=config["max_mem"],
-        time_min=config["max_time"],
-        runtime=config["max_time"],
+        mem_mb=16_000,
+        time_min=4 * 60,
+        runtime=4 * 60,
     run:
-        from bio2zarr import vcf
+        import json
 
-        # Snakemake creates the output dir - bio2zarr then complains that the output exists
-        # so we need to remove it first
-        try:
-            os.rmdir(data_dir / "zarr_vcfs" / f"chr{wildcards.chrom_num}" / "data.zarr")
-        except FileNotFoundError:
-            pass
-        vcf.encode(
-            input[0],
-            output[0].replace(".vcf_done", ""),
-            input[1],
-            worker_processes=threads,
-            max_memory=config["max_mem"],
+        shell(
+            f"python -m bio2zarr vcf2zarr dencode-init --force --num-partitions {config['bio2zarr']['num_partitions']} --variants-chunk-size {config['bio2zarr']['variants_chunk_size']} {Path(input[0]).parent} {Path(output[0]).parent}"
         )
-        # Remove the consolidated metadata file
-        os.remove(output[0].replace(".vcf_done", ".zmetadata"))
-        Path(output[0]).touch()
+        with open(Path(output[0]).parent / "wip" / "metadata.json", "r") as f:
+            md = json.load(f)
+        with open(output[0], "w") as f:
+            f.write(str(len(md["partitions"])))
+
+
+def dencode_partitions(wildcards):
+    checkpoint_output = checkpoints.bio2zarr_dencode_init.get(
+        chrom_num=wildcards.chrom_num
+    )
+    with open(checkpoint_output.output[0], "r") as f:
+        num_partitions = int(f.read())
+    print(
+        [
+            data_dir
+            / "zarr_vcfs"
+            / f"chr{wildcards.chrom_num}"
+            / "data.zarr"
+            / f".done_{p}"
+            for p in range(num_partitions)
+        ]
+    )
+    return [
+        data_dir
+        / "zarr_vcfs"
+        / f"chr{wildcards.chrom_num}"
+        / "data.zarr"
+        / f".done_{p}"
+        for p in range(num_partitions)
+    ]
+
+
+rule bio2zarr_dencode_partition:
+    input:
+        data_dir / "zarr_vcfs" / "chr{chrom_num}" / "data.zarr" / "num_partitions",
+    output:
+        data_dir / "zarr_vcfs" / "chr{chrom_num}" / "data.zarr" / ".done_{partition}",
+    threads: 1
+    resources:
+        mem_mb=8_000,
+        time_min=4 * 60,
+        runtime=4 * 60,
+    run:
+        shell(
+            f"python -m bio2zarr vcf2zarr dencode-partition {Path(input[0]).parent} {wildcards.partition} && touch {output[0]}"
+        )
+
+
+rule bio2zarr_dencode_finalise:
+    input:
+        dencode_partitions,
+    output:
+        data_dir / "zarr_vcfs" / "chr{chrom_num}" / "data.zarr" / ".vcf_done",
+    threads: 1
+    resources:
+        mem_mb=16_000,
+        time_min=4 * 60,
+        runtime=4 * 60,
+    run:
+        shell(
+            f"python -m bio2zarr vcf2zarr dencode-finalise {Path(output[0]).parent} && touch {output[0]}"
+        )
 
 
 rule load_ancestral_fasta:

--- a/Snakefile
+++ b/Snakefile
@@ -207,6 +207,7 @@ rule bio2zarr_dencode_finalise:
         shell(
             f"python -m bio2zarr vcf2zarr dencode-finalise {Path(output[0]).parent} && touch {output[0]}"
         )
+        shell(f"rm -rf {Path(output[0]).parent}/.zmetadata*")
 
 
 rule load_ancestral_fasta:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -93,7 +93,8 @@ filters:
         threshold_sites_per_kbp: 100
 
 bio2zarr:
-  column_chunk_size: 128
+  variants_chunk_size: 20_000
+  num_partitions: 500
 
 # Dask is optional for the following step, if you're on a single machine set these
 # to False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/benjeffery/tsinfer.git@sample_mask
-git+https://github.com/nspope/tsdate.git@fix-timescale
+git+https://github.com/tskit-dev/tsinfer.git@main
+git+https://github.com/tskit-dev/tsdate.git@main
 sgkit==0.8.0
 aiohttp==3.8.5
 cyvcf2==0.30.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ snakemake==7.32.4
 bokeh==3.2.2
 pyfaidx==0.7.2.2
 matplotlib==3.8.0
-bio2zarr==0.0.8
+bio2zarr==0.1.0
 #https://github.com/snakemake/snakemake/issues/2607#issuecomment-1948732242
 pulp==2.7.0

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -92,7 +92,8 @@ filters:
         threshold_sites_per_kbp: 10
 
 bio2zarr:
-  column_chunk_size: 128
+  variants_chunk_size: 20_000
+  num_partitions: 16
 
 # Dask is optional for the following steps, if you're on a single machine set these
 # to False


### PR DESCRIPTION
@jeromekelleher Here's how the snakemake pipeline ended up. It's a little bit messy as the wip/metdata.json files can't be used to count the partitions as they get moved and a subsequent snakemake can't build the graph.

@savitakartik 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new bio2zarr workflow for dexplode and dencode processes with improved resource allocation and command execution.

- **Configuration Changes**
  - Updated `config.yaml.example` and `test_config.yaml` with new `variants_chunk_size` and added `num_partitions`.

- **Dependency Updates**
  - Updated `requirements.txt` to use main branches of `tsinfer` and `tsdate` from the `tskit-dev` organization.
  - Upgraded `bio2zarr` version from `0.0.8` to `0.1.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->